### PR TITLE
Suggest executing pip without sudo (#118)

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -22,7 +22,7 @@ requirements you’ll need to make sure your system has before you start.
 The best way to install Frida's CLI tools is via [PyPI][]:
 
 {% highlight bash %}
-$ sudo pip install frida-tools
+$ pip install frida-tools
 {% endhighlight %}
 
 If you have problems installing Frida, check out the [troubleshooting][] page or

--- a/_docs/quickstart.md
+++ b/_docs/quickstart.md
@@ -7,7 +7,7 @@ permalink: /docs/quickstart/
 For the impatient, here's how to do function tracing with Frida:
 
 {% highlight bash %}
-~ $ sudo pip install frida-tools
+~ $ pip install frida-tools
 ~ $ frida-trace -i "recv*" -i "read*" *twitter*
 recv: Auto-generated handler: …/recv.js
 # (snip)

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ overview: true
         <p class="line">
           <span class="path">~</span>
           <span class="prompt">$</span>
-          <span class="command">sudo pip install frida-tools</span>
+          <span class="command">pip install frida-tools</span>
         </p>
         <p class="line">
           <span class="path">~</span>


### PR DESCRIPTION
Executing pip install with administrator privileges can be harmful and
is considered insecure.